### PR TITLE
suppression liens internes dans le readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Il s'agissait de définir un corpus, et de le soumettre à un processus d'HTR (*
 
 ## Corpus retenu
 
-Nous avons choisi de travailler sur la correspondance active de Hector Berlioz adressée à sa sœur Anne-Marguerite "Nanci" Berlioz. Cette correspondance est disponible [en ligne](https://gallica.bnf.fr/services/engine/search/sru?operation=searchRetrieve&exactSearch=false&collapsing=true&version=1.2&query=((dc.creator%20adj%20%22berlioz%20hector%22%20or%20dc.contributor%20adj%20%22berlioz%20hector%22%20)%20and%20(dc.creator%20adj%20%22berlioz%20nanci%22%20or%20dc.contributor%20adj%20%22berlioz%20nanci%22%20)%20)%20&suggest=10&keywords=berlioz%20hector%20berlioz%20nanci) (Source gallica.bnf.fr / Bibliothèque nationale de France). L'ensemble des lettres adressées à Nanci Berlioz représentait un volume trop important pour notre projet, aussi nous les avons sélectionnées, par souci de cohérence, selon un ordre chronologique (voir le [tableau de gestion](https://github.com/Lienceard/TNAH-2021-Projet-Correspondance-Berlioz/blob/main/tableau_de_gestion.md) pour la liste exacte des lettres transcrites).
+Nous avons choisi de travailler sur la correspondance active de Hector Berlioz adressée à sa sœur Anne-Marguerite "Nanci" Berlioz. Cette correspondance est disponible [en ligne](https://gallica.bnf.fr/services/engine/search/sru?operation=searchRetrieve&exactSearch=false&collapsing=true&version=1.2&query=((dc.creator%20adj%20%22berlioz%20hector%22%20or%20dc.contributor%20adj%20%22berlioz%20hector%22%20)%20and%20(dc.creator%20adj%20%22berlioz%20nanci%22%20or%20dc.contributor%20adj%20%22berlioz%20nanci%22%20)%20)%20&suggest=10&keywords=berlioz%20hector%20berlioz%20nanci) (Source gallica.bnf.fr / Bibliothèque nationale de France). L'ensemble des lettres adressées à Nanci Berlioz représentait un volume trop important pour notre projet, aussi nous les avons sélectionnées, par souci de cohérence, selon un ordre chronologique (voir le tableau de gestion) pour la liste exacte des lettres transcrites).
 
 Au sein d'eScriptorium, nous avons choisi de soumettre notre corpus au modèle d'entraînement `Modèle Manuscrit 19e Lectaurep`, fruit du projet Lectaurep (LECTure Automatique de REPertoires).
 
@@ -30,16 +30,16 @@ Pour l'alignement, la transcription, la gestion de projet, les corrections :
 
 Ce dépôt est organisé de la manière suivante :
 
-1. Un [dossier de comptes rendus de réunions](https://github.com/Lienceard/TNAH-2021-Projet-Correspondance-Berlioz/tree/main/comptes_rendus_reunions) : ce dossier contient de la documentation sur les réunions ayant permis de mettre en place le projet. D'autres choix ont, eux, été discutés dans les [issues](https://github.com/Lienceard/TNAH-2021-Projet-Correspondance-Berlioz/issues).
+1. Un dossier de comptes rendus de réunions : ce dossier contient de la documentation sur les réunions ayant permis de mettre en place le projet. D'autres choix ont, eux, été discutés dans les issues.
 2. Un dossier "donnees" contenant un dossier par lettre transcrite, qui comprend :
     * Les transcriptions de la lettre au format XML (standard ALTO).
     * Les images de la lettre.
     * Un sous-dossier pour les transcriptions finales de la lettre au format texte.
     * Un sous-dossier pour les transcriptions brutes, telles que générées par HTR sur eScriptorium, non corrigées.
 3. Un README de présentation du projet (le présent fichier).
-4. Un [fichier](https://github.com/Lienceard/TNAH-2021-Projet-Correspondance-Berlioz/blob/main/choix_exports_et_conventions_de_nommage.md) qui présente les choix d'exports et les conventions de nommage que nous avons adoptés.
-5. Un [tableau de gestion](https://github.com/Lienceard/TNAH-2021-Projet-Correspondance-Berlioz/blob/main/tableau_de_gestion.md) qui récapitule les lettres transcrites, leurs liens vers Gallica. Il permet également une gestion et une visualisation des étapes du projet.
-6. Un [fichier](https://github.com/Lienceard/TNAH-2021-Projet-Correspondance-Berlioz/blob/main/normes_transcription.md) qui récapitule les normes de transcription que nous avons adoptées.
+4. Un fichier qui présente les choix d'exports et les conventions de nommage que nous avons adoptés.
+5. Un tableau de gestion qui récapitule les lettres transcrites, leurs liens vers Gallica. Il permet également une gestion et une visualisation des étapes du projet.
+6. Un fichier qui récapitule les normes de transcription que nous avons adoptées.
 
 ## État du projet
 


### PR DESCRIPTION
Suite à nos discussions dans l'issue #47 , je propose la suppression des liens internes présents dans le read me pour éviter des liens morts après transfert de la propriété du dépôt.