### PR TITLE
suppression lien interne dans tableau de gestion

### DIFF
--- a/tableau_de_gestion.md
+++ b/tableau_de_gestion.md
@@ -1,4 +1,4 @@
-Se référer à l'issue #3 (https://github.com/Lienceard/TNAH-2021-Projet-Correspondance-Berlioz/issues/3) pour plus d'informations.
+Se référer à l'issue #3 pour plus d'informations.
 
 | ID | Date            | Url                                                          | Identifiant                 | Personne en charge | Nombre estimé de lignes | Nombre d'images | Segmentation | Transcription | Relecture | Validation |
 |----|-----------------|--------------------------------------------------------------|-----------------------------|--------------------|-------------------------|-----------------|--------------|---------------|-----------|------------|


### PR DESCRIPTION
Suite à nos discussions dans l'issue #47 , je propose la suppression des liens internes dans le tableau de gestion pour éviter des liens morts après transfert de la propriété du dépôt.